### PR TITLE
Fixing argument handling in the JSRT C# sample

### DIFF
--- a/Chakra Samples/JSRT Win32 Hosting Samples/Edge JSRT Samples/C#/Program.cs
+++ b/Chakra Samples/JSRT Win32 Hosting Samples/Edge JSRT Samples/C#/Program.cs
@@ -249,7 +249,7 @@ namespace ChakraHost
             int returnValue = 1;
             CommandLineArguments commandLineArguments = ProcessArguments(arguments);
 
-            if (arguments.Length - commandLineArguments.ArgumentsStart < 0)
+            if (arguments.Length - commandLineArguments.ArgumentsStart < 1)
             {
                 Console.Error.WriteLine("usage: chakrahost [-debug] [-profile] <script name> <arguments>");
                 return returnValue;

--- a/Chakra Samples/JSRT Win32 Hosting Samples/Edge JSRT Samples/VB/Program.vb
+++ b/Chakra Samples/JSRT Win32 Hosting Samples/Edge JSRT Samples/VB/Program.vb
@@ -224,7 +224,7 @@ Public Module Program
         Dim returnValue As Integer = 1
         Dim commandLineArguments As CommandLineArguments = ProcessArguments(arguments)
 
-        If arguments.Length - commandLineArguments.ArgumentsStart < 0 Then
+        If arguments.Length - commandLineArguments.ArgumentsStart < 1 Then
             Console.Error.WriteLine("usage: chakrahost [-debug] [-profile] <script name> <arguments>")
             Return returnValue
         End If

--- a/Chakra Samples/JSRT Win32 Hosting Samples/Legacy JSRT Samples/C#/Program.cs
+++ b/Chakra Samples/JSRT Win32 Hosting Samples/Legacy JSRT Samples/C#/Program.cs
@@ -262,7 +262,7 @@ namespace ChakraHost
             int returnValue = 1;
             CommandLineArguments commandLineArguments = ProcessArguments(arguments);
 
-            if (arguments.Length - commandLineArguments.ArgumentsStart < 0)
+            if (arguments.Length - commandLineArguments.ArgumentsStart < 1)
             {
                 Console.Error.WriteLine("usage: chakrahost [-debug] [-profile] <script name> <arguments>");
                 return returnValue;

--- a/Chakra Samples/JSRT Win32 Hosting Samples/Legacy JSRT Samples/VB/Program.vb
+++ b/Chakra Samples/JSRT Win32 Hosting Samples/Legacy JSRT Samples/VB/Program.vb
@@ -234,7 +234,7 @@ Public Module Program
         Dim returnValue As Integer = 1
         Dim commandLineArguments As CommandLineArguments = ProcessArguments(arguments)
 
-        If arguments.Length - commandLineArguments.ArgumentsStart < 0 Then
+        If arguments.Length - commandLineArguments.ArgumentsStart < 1 Then
             Console.Error.WriteLine("usage: chakrahost [-debug] [-profile] <script name> <arguments>")
             Return returnValue
         End If

--- a/ChakraCore Samples/JSRT Hosting Samples/C#/ChakraCoreHost/ChakraCoreHost.cs
+++ b/ChakraCore Samples/JSRT Hosting Samples/C#/ChakraCoreHost/ChakraCoreHost.cs
@@ -207,7 +207,7 @@ namespace ChakraHost
             CommandLineArguments commandLineArguments;
             commandLineArguments.ArgumentsStart = 0;
 
-            if (arguments.Length - commandLineArguments.ArgumentsStart < 0)
+            if (arguments.Length - commandLineArguments.ArgumentsStart < 1)
             {
                 Console.Error.WriteLine("usage: chakrahost <script name> <arguments>");
                 return returnValue;


### PR DESCRIPTION
The argument parsing is expecting at least one argument, but the check is validating against zero.