### PR TITLE
new-sample: Embed ChakraCore using CMake

### DIFF
--- a/ChakraCore Samples/Hello World/CMake/CMakeLists.txt
+++ b/ChakraCore Samples/Hello World/CMake/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.2)
+project (HelloWorld)
+
+# set(ICU_INCLUDE_PATH ......) # -> if you have a custom ICU setup
+# set(CHAKRACORE_PATH "................/Github/ChakraCore/") # -> location of the ChakraCore Repo
+# set(CHAKRACORE_LIB_TYPE ....Release or Test or Debug) # -> by default Release
+if (NOT CHAKRACORE_PATH)
+    message (FATAL_ERROR "You should set CHAKRACORE_PATH to run this sample.
+            You may set it from CMake or command line (-DCHAKRACORE_PATH=<path>)
+            ")
+endif()
+
+message ("-- Compiling ChakraCore..")
+
+# Embed ChakraCore
+include(ChakraCoreEmbed.cmake)
+
+add_executable (Sample sample.cpp)
+
+target_include_directories (Sample
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CHAKRACORE_INCLUDE_PATH} # add ChakraCore include path
+  )
+
+target_link_libraries (Sample
+  ${CHAKRACORE_LINKER_OPTIONS} # add ChakraCore linker options
+  )

--- a/ChakraCore Samples/Hello World/CMake/ChakraCoreEmbed.cmake
+++ b/ChakraCore Samples/Hello World/CMake/ChakraCoreEmbed.cmake
@@ -1,0 +1,89 @@
+#-------------------------------------------------------------------------------------------------------
+# Copyright (C) Microsoft. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+#-------------------------------------------------------------------------------------------------------
+
+if (NOT ICU_INCLUDE_PATH)
+    if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+        set (ICU_INCLUDE_PATH "/usr/local/opt/icu4c/include")
+        set (ICU_INCLUDE_PATH_ARG "--icu=${ICU_INCLUDE_PATH}")
+    endif()
+else()
+    set (ICU_INCLUDE_PATH_ARG "--icu=${ICU_INCLUDE_PATH}")
+endif()
+
+if (NOT CHAKRACORE_LIB_TYPE)
+    set (CHAKRACORE_LIB_TYPE "Release")
+    set (CHAKRACORE_WIN_SHORT "x64_release")
+    set (COREE_LIB_TYPE "")
+elseif (CHAKRACORE_LIB_TYPE STREQUAL "Test")
+    set (CHAKRACORE_LIB_TYPE "Test")
+    set (COREE_LIB_TYPE "--test-build")
+elseif (CHAKRACORE_LIB_TYPE STREQUAL "Release")
+    set (CHAKRACORE_LIB_TYPE "Release")
+    set (CHAKRACORE_WIN_SHORT "x64_release")
+    set (COREE_LIB_TYPE "")
+elseif (CHAKRACORE_LIB_TYPE STREQUAL "Debug")
+    set (CHAKRACORE_LIB_TYPE "Debug")
+    set (COREE_LIB_TYPE "--debug")
+    set (CHAKRACORE_WIN_SHORT "x64_debug")
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set (COREE_SCRIPT_EXEC_COMMAND "msbuild")
+    # todo: allow platform selection ?
+    set (COREE_SCRIPT_ARGS "/m" "/p:Configuration=${CHAKRACORE_LIB_TYPE}" "/p:Platform=x64" "Build\\Chakra.Core.sln")
+else()
+    set (COREE_SCRIPT_EXEC_COMMAND "./build.sh")
+    set (COREE_SCRIPT_ARGS ${ICU_INCLUDE_PATH_ARG} ${COREE_LIB_TYPE} "-j=2")
+endif()
+
+execute_process(COMMAND ${COREE_SCRIPT_EXEC_COMMAND} ${COREE_SCRIPT_ARGS}
+    WORKING_DIRECTORY ${CHAKRACORE_PATH}
+    RESULT_VARIABLE COREE_CMD_EXIT_CODE
+    OUTPUT_VARIABLE COREE_EXEC_OUTPUT
+    )
+
+if (COREE_CMD_EXIT_CODE)
+    message(FATAL_ERROR "ChakraCore build has failed with error: ${COREE_CMD_EXIT_CODE} ${COREE_EXEC_OUTPUT}")
+endif()
+
+if (NOT CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set (CHAKRACORE_BUILD_PATH "${CHAKRACORE_PATH}/out/${CHAKRACORE_LIB_TYPE}/lib/")
+    find_library(CHAKRACORE_STATIC_LIB_PATH ChakraCoreStatic PATHS ${CHAKRACORE_BUILD_PATH} NO_DEFAULT_PATH)
+    set (CHAKRACORE_INCLUDE_PATH
+        "${CHAKRACORE_PATH}/lib/Jsrt/")
+else() # Windows
+    set (CHAKRACORE_BUILD_PATH "${CHAKRACORE_PATH}\\Build\\VcBuild\\bin\\${CHAKRACORE_WIN_SHORT}")
+    find_library(CHAKRACORE_STATIC_LIB_PATH ChakraCore PATHS ${CHAKRACORE_BUILD_PATH} NO_DEFAULT_PATH)
+    set (CHAKRACORE_LINKER_OPTIONS ${CHAKRACORE_STATIC_LIB_PATH})
+    set (CHAKRACORE_INCLUDE_PATH
+        "${CHAKRACORE_PATH}\\lib\\Jsrt\\")
+endif()
+message ("ChakraCore Library is available at ${CHAKRACORE_STATIC_LIB_PATH}")
+
+if (CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    if (ICU_INCLUDE_PATH)
+        set(ICU_CC_PATH "${ICU_INCLUDE_PATH}/../lib/")
+        find_library(ICUUC icuuc PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+        find_library(ICU18 icui18n PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+        find_library(ICUDATA icudata PATHS ${ICU_CC_PATH} NO_DEFAULT_PATH)
+        if(ICUUC)
+            set(ICULIB
+              ${ICUUC}
+              ${ICU18}
+              ${ICUDATA}
+              )
+        endif()
+    endif()
+    set (CHAKRACORE_LINKER_OPTIONS ${CHAKRACORE_STATIC_LIB_PATH}
+      "-framework CoreFoundation"
+      "-framework Security"
+      "${ICULIB}")
+elseif (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    set (CHAKRACORE_LINKER_OPTIONS
+      ${CHAKRACORE_STATIC_LIB_PATH}
+      icuuc
+      pthread
+      dl)
+endif()

--- a/ChakraCore Samples/Hello World/CMake/README.md
+++ b/ChakraCore Samples/Hello World/CMake/README.md
@@ -1,0 +1,50 @@
+# ChakraCore CMake Sample
+This sample shows how to embed ChakraCore with
+[JavaScript Runtime (JSRT) APIs](http://aka.ms/corejsrtref), and complete the following tasks:
+
+1. Initializing the JavaScript runtime and creating an execution context.
+2. Running scripts and handling values.
+3. Printing out script results.
+
+## Build ChakraCore
+[Here] (https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore) you will
+find the details on `How to build ChakraCore for your platform.`
+
+## Build and Run the Sample
+
+### Build
+
+#### Linux/OSX
+```
+> cmake . -DCHAKRACORE_PATH=<ChakraCore Path>
+> make
+```
+
+#### Windows
+```
+> cmake . -DCHAKRACORE_PATH=<ChakraCore Path> -G "Visual Studio 14 2015 Win64"
+> msbuild /p:Platform=x64 HelloWorld.sln
+```
+
+`Visual Studio 14` is not a must! You may use another version (i.e. 2017 etc.)
+
+As a last step, copy ChakraCore.dll (you will find it under the ChakraCore build
+path) into `Debug/` folder
+
+### Run
+
+#### Linux/OSX
+```
+> ./Sample
+```
+
+#### Windows
+```
+> Debug\Sample.exe
+```
+
+## Help us improve our samples
+Help us improve out samples by sending us a pull-request or opening a [GitHub Issue](https://github.com/Microsoft/Chakra-Samples/issues/new).
+
+Copyright (c) Microsoft. All rights reserved.  Licensed under the MIT license.  
+See LICENSE file in the project root for full license information.

--- a/ChakraCore Samples/Hello World/CMake/sample.cpp
+++ b/ChakraCore Samples/Hello World/CMake/sample.cpp
@@ -1,0 +1,79 @@
+//-------------------------------------------------------------------------------------------------------
+// Copyright (C) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+//-------------------------------------------------------------------------------------------------------
+
+#include "ChakraCore.h"
+#include <stdlib.h>
+#include <stdio.h>
+#include <string>
+#include <cstring>
+
+#define FAIL_CHECK(cmd)                     \
+    do                                      \
+    {                                       \
+        JsErrorCode errCode = cmd;          \
+        if (errCode != JsNoError)           \
+        {                                   \
+            printf("Error %d at '%s'\n",    \
+                errCode, #cmd);             \
+            return 1;                       \
+        }                                   \
+    } while(0)
+
+using namespace std;
+
+#ifndef nullptr
+#define nullptr 0
+#endif
+
+int main()
+{
+    JsRuntimeHandle runtime;
+    JsContextRef context;
+    JsValueRef result;
+    unsigned currentSourceContext = 0;
+
+    const char* script = "(()=>{return \'SUCCESS\';})()";
+    size_t length = strlen(script);
+
+    // Create a runtime.
+    JsCreateRuntime(JsRuntimeAttributeNone, nullptr, &runtime);
+
+    // Create an execution context.
+    JsCreateContext(runtime, &context);
+
+    // Now set the current execution context.
+    JsSetCurrentContext(context);
+
+    JsValueRef fname;
+    FAIL_CHECK(JsCreateString("sample", strlen("sample"), &fname));
+
+    JsValueRef scriptSource;
+    FAIL_CHECK(JsCreateString(script, length, &scriptSource));
+
+    // Run the script.
+    FAIL_CHECK(JsRun(scriptSource, currentSourceContext++, fname,
+        JsParseScriptAttributeNone, &result));
+
+    // Convert your script result to String in JavaScript; redundant if your script returns a String
+    JsValueRef resultJSString;
+    FAIL_CHECK(JsConvertValueToString(result, &resultJSString));
+
+    // Project script result back to C++.
+    char *resultSTR = nullptr;
+    size_t stringLength;
+    FAIL_CHECK(JsCopyString(resultJSString, nullptr, 0, &stringLength));
+    resultSTR = (char*)malloc(stringLength + 1);
+    FAIL_CHECK(JsCopyString(resultJSString, resultSTR, stringLength + 1, nullptr));
+    resultSTR[stringLength] = 0;
+
+    printf("Result -> %s \n", resultSTR);
+    free(resultSTR);
+
+    // Dispose runtime
+    JsSetCurrentContext(JS_INVALID_REFERENCE);
+    JsDisposeRuntime(runtime);
+
+    return 0;
+}


### PR DESCRIPTION
Linux / Windows / OSX

Embed ChakraCore via CMake using `ChakraCoreEmbed.cmake` as shown from `CMakeLists.txt`