### PR TITLE
Removed JavaScriptPropertyId.ToString()

### DIFF
--- a/ChakraCore Samples/Hello World/Windows/C#/HelloWorld/Hosting/JavaScriptPropertyId.cs
+++ b/ChakraCore Samples/Hello World/Windows/C#/HelloWorld/Hosting/JavaScriptPropertyId.cs
@@ -128,14 +128,5 @@
         {
             return id.ToInt32();
         }
-
-        /// <summary>
-        ///     Converts the property ID to a string.
-        /// </summary>
-        /// <returns>The name of the property ID.</returns>
-        public override string ToString()
-        {
-            return Name;
-        }
     }
 }


### PR DESCRIPTION
This causes Visual Studio 2017 crash when debugging .NET Core version - Crash is caused by the Locals window.